### PR TITLE
Update upstream

### DIFF
--- a/configWithTest.sample.js
+++ b/configWithTest.sample.js
@@ -2,12 +2,12 @@ const joi = require('joi')
 
 const envVarsSchema = joi.object({  
   NODE_ENV: joi.string()
-    .allow(['development', 'production', 'test', 'provision'])
+    .valid(['development', 'production', 'test', 'provision'])
     .required(),
   PORT: joi.number()
     .required(),
   LOGGER_LEVEL: joi.string()
-    .allow(['error', 'warn', 'info', 'verbose', 'debug', 'silly'])
+    .valid(['error', 'warn', 'info', 'verbose', 'debug', 'silly'])
     .default('info'),
   LOGGER_ENABLED: joi.boolean()
     .truthy('TRUE')


### PR DESCRIPTION
The current validation using `allow` will allow any kind of string, not only the specified ones. 
`NODE_ENV=foo` is totally valid. Using `valid` instead should fix this.